### PR TITLE
Don't assume the name of the base directory

### DIFF
--- a/patterns/simple-factory/pom.xml
+++ b/patterns/simple-factory/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.example</groupId>
 		<artifactId>java-samples</artifactId>
 		<version>1.0-SNAPSHOT</version>
-		<relativePath>../../../java-samples/pom.xml</relativePath>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
 	<groupId>org.example.patterns.creational</groupId>

--- a/servlet/simple-schedule-configurer/pom.xml
+++ b/servlet/simple-schedule-configurer/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.example</groupId>
 		<artifactId>java-samples</artifactId>
 		<version>1.0-SNAPSHOT</version>
-		<relativePath>../../../java-samples/pom.xml</relativePath>		
+		<relativePath>../../pom.xml</relativePath>		
 	</parent>
 	<groupId>org.example</groupId>
 	<artifactId>simple-schedule-configurer</artifactId>

--- a/testing/logback-logging-to-in-memory-stream/pom.xml
+++ b/testing/logback-logging-to-in-memory-stream/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.example</groupId>
 		<artifactId>java-samples</artifactId>
 		<version>1.0-SNAPSHOT</version>
-		<relativePath>../../../java-samples/pom.xml</relativePath>		
+		<relativePath>../../pom.xml</relativePath>		
 	</parent>	
 	<groupId>org.example.logging</groupId>
 	<artifactId>logback-logging-to-in-memory-stream</artifactId>

--- a/xml/jaxb/generate-code-from-xsd/pom.xml
+++ b/xml/jaxb/generate-code-from-xsd/pom.xml
@@ -7,7 +7,7 @@
 		<groupId>org.example</groupId>
 		<artifactId>java-samples</artifactId>
 		<version>1.0-SNAPSHOT</version>
-		<relativePath>../../../../java-samples/pom.xml</relativePath>
+		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 	<groupId>org.example</groupId>
 	<artifactId>generate-code-from-xsd</artifactId>

--- a/xml/schema-validation/pom.xml
+++ b/xml/schema-validation/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.example</groupId>
 		<artifactId>java-samples</artifactId>
 		<version>1.0-SNAPSHOT</version>
-		<relativePath>../../../java-samples/pom.xml</relativePath>		
+		<relativePath>../../pom.xml</relativePath>		
 	</parent>	
 	<groupId>org.example.xml.validation</groupId>
 	<artifactId>schema-validation</artifactId>

--- a/xml/testing/comparing-with-xmlunit/pom.xml
+++ b/xml/testing/comparing-with-xmlunit/pom.xml
@@ -7,7 +7,7 @@
 		<groupId>org.example</groupId>
 		<artifactId>java-samples</artifactId>
 		<version>1.0-SNAPSHOT</version>
-		<relativePath>../../../../java-samples/pom.xml</relativePath>
+		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 	<groupId>org.example.xml.test</groupId>
 	<artifactId>comparing-with-xmlunit</artifactId>

--- a/xml/xpath-query/pom.xml
+++ b/xml/xpath-query/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.example</groupId>
 		<artifactId>java-samples</artifactId>
 		<version>1.0-SNAPSHOT</version>
-		<relativePath>../../../java-samples/pom.xml</relativePath>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<groupId>org.example.xml.xpath</groupId>
 	<artifactId>xpath-query</artifactId>


### PR DESCRIPTION
The current usage of <relativePath> assumes the base folder is guaranteed to have the name `java-samples`

This is not the case when:
1. A specific directory is passed as the 2nd directory into `git clone` 
2. The folder is `mv`ed.

`muse` would start to work with this PR since it is using `code` as the base folder instead of `java-samples`