### PR TITLE
Update logback-classic to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
-				<version>1.5.7</version>
+				<version>1.5.15</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
to get rid of a couple of medium-low vulnerabilities reported by Snyk (creates unnecessary formatting differences in it's PR).